### PR TITLE
Bugfix incorrect crate reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ _DIRECT_ = []
 
 [dependencies]
 winapi = {version = "0.3.9", features = ["ntdef", "winnt"]}
-ntapi = "0.3.7"
+ntapi = "0.4.0"

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -12,7 +12,7 @@ macro_rules! syscall {
             let _ = $y;
             cnt += 1;
         )+
-        crate::syscall::do_syscall(ssn, cnt, $($y), +)
+        $crate::syscall::do_syscall(ssn, cnt, $($y), +)
     }}
 }
 
@@ -27,7 +27,7 @@ macro_rules! syscall {
             let _ = $y;
             cnt += 1;
         )+
-        crate::syscall::do_syscall(ssn, addr, cnt, $($y), +)
+        $crate::syscall::do_syscall(ssn, addr, cnt, $($y), +)
     }}
 }
 


### PR DESCRIPTION
* change `crate` to `$crate` to always refer to the `rust_syscalls` crate. Fixes `unresolved import` s when used in submodules. Example:

```rust
mod poc {
    use rust_syscalls::syscall;
    pub fn poc() {
        unsafe { syscall!("NtClose", -1) };
    }
}

fn main() {
    poc::poc();
}
```

Results in:

```
error[E0433]: failed to resolve: unresolved import
 --> src/main.rs:4:18
  |
4 |         unsafe { syscall!("NtClose", -1) };
  |                  ^^^^^^^^^^^^^^^^^^^^^^^
  |                  |
  |                  unresolved import
  |                  help: a similar path exists: `rust_syscalls::syscall`
  |
  = note: this error originates in the macro `syscall` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0433`.
```

* Bump NTAPI to 0.4.0